### PR TITLE
Bubble game: reset score bug

### DIFF
--- a/BubbleGame/script.js
+++ b/BubbleGame/script.js
@@ -116,13 +116,11 @@ startBtn.addEventListener("click", () => {
 
 retplayBtn.addEventListener("click", () => {
     score = 0;
+    scoreBox.innerHTML = score;
+    scoreBox.style.color = "rgb(28, 76, 223)";
     gameOverScreen.style.display = "none"
     generateHit();
     timeFunction();
     bubbleMaker(panelContent);
     time = 61;
 });
-
-
-
-

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 
     </a>
 
-    <a href="BubbleGame/" class="game game1" target="_blank">
+    <a href="BubbleGame/index.html" class="game game1" target="_blank">
       <img src="assets/the_bubble_game.png" alt="">
       <h3 class="game-text">The Bubble Game</h3>
 


### PR DESCRIPTION
Fixed bug so that whenever the "play again" button is pressed the score is reset to 0. Addresses issue #34 