### PR TITLE
Bubble game: event click bug

### DIFF
--- a/BubbleGame/script.js
+++ b/BubbleGame/script.js
@@ -91,24 +91,25 @@ function generateHit() {
 }
 
 panelContent.addEventListener("click", (dets)=>{//Event bubbling
-    if(dets.target.innerHTML == hitBox.innerHTML){
-        score += 10;
-        scoreBox.innerHTML = score;
-        if (score >= 0) {
-            scoreBox.style.color = "rgb(28, 76, 223)";
+    if(dets.target.classList.contains('bubble')) {
+        if(dets.target.innerHTML == hitBox.innerHTML){
+            score += 10;
+            scoreBox.innerHTML = score;
+            if (score >= 0) {
+                scoreBox.style.color = "rgb(28, 76, 223)";
+            }
+            generateHit();
+            bubbleMaker(panelContent);
         }
-        generateHit();
-        bubbleMaker(panelContent);
-    }
-    else{
-        score -= 10;
-        scoreBox.innerHTML = score;
-        if (score < 0) {
-            scoreBox.style.color = "red";
+        else{
+            score -= 10;
+            scoreBox.innerHTML = score;
+            if (score < 0) {
+                scoreBox.style.color = "red";
+            }
+            generateHit();
+            bubbleMaker(panelContent);
         }
-        generateHit();
-        bubbleMaker(panelContent);
-
     }
 });
 


### PR DESCRIPTION
Fixed bug that affected scoring when clicking outside of the bubble. Added if-statement to check the click event so that the score is only changed when clicking on a bubble. Addresses issue #33 